### PR TITLE
Fix wrong styling on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattilsynet/designsystem",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Design system for Mattilsynet",
   "main": "index.js",
   "private": false,

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -40,6 +40,7 @@ fieldset {
 .form-field + button,
 .form-field + fieldset,
 fieldset + button,
+fieldset + fieldset,
 fieldset + .form-label {
   margin-top: var(--form-group-spacer);
 }
@@ -57,7 +58,11 @@ label.form-label {
   font-weight: var(--font-weight-normal);
   line-height: 1;
 }
-
+.form-field.error {
+  &:focus-visible {
+    box-shadow: 0 0 0 0.25rem #e2312880;
+  }
+}
 .form-field {
   @include error-style;
 
@@ -168,7 +173,7 @@ label.form-label {
     place-content: center;
     width: var(--dimention);
     height: var(--dimention);
-    border: 0.15em solid var(--border-color);
+    border: $border-width-small solid var(--border-color);
   }
 }
 
@@ -176,6 +181,7 @@ label.form-label {
   .input__control {
     @include error-style;
     @include focus-shadow(var(--color-primary-50), var(--color-primary));
+    @include radio-check-error-style;
 
     appearance: none;
     -moz-appearance: none;
@@ -200,6 +206,7 @@ label.form-label {
   .input__control {
     @include error-style;
     @include focus-shadow(var(--color-primary-50), var(--color-primary));
+    @include radio-check-error-style;
 
     appearance: none;
     -moz-appearance: none;

--- a/src/scss/utilities/_mixins.scss
+++ b/src/scss/utilities/_mixins.scss
@@ -1,3 +1,5 @@
+@use '../theme' as *;
+
 @mixin focus-outline() {
   --outline-color: var(--color-primary-50);
   --outline-size: 2px;
@@ -41,13 +43,18 @@
   &.error {
     $error-focus-color: var(--color-error-50);
 
-    border-color: var(--color-error);
+    border: $border-width-regular solid var(--color-error);
 
     &:focus {
       border-color: var(--color-error);
       outline: none;
       box-shadow: 0 0 0 0.25rem $error-focus-color;
     }
+  }
+}
+
+@mixin radio-check-error-style {
+  &.error {
     + label {
       color: var(--color-error);
     }

--- a/stories/components/form/AllForm.stories.svelte
+++ b/stories/components/form/AllForm.stories.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+  import {Meta, Story} from '@storybook/addon-svelte-csf';
+  import {countCharacters} from '../../../src/ts/count-characters';
+  const radioName = 'radiobuttons';
+  const checkboxName = 'checkboxes';
+  const radioOptions = [
+    {
+      text: 'Dere kan kontakte meg',
+      value: 'yes'
+    },
+    {
+      text: 'Jeg ønsker å være anonym',
+      value: 'no'
+    }
+  ];
+  const checkBoxOptions = [
+    {
+      text: 'Is',
+      value: 'Is'
+    },
+    {
+      text: 'Pizza',
+      value: 'Pizza'
+    }
+  ];
+</script>
+
+<Meta
+  title="Components/Form/All"
+  args={{
+    label: 'Når skjedde det?',
+    radioLabel: 'Kan vi kontakte deg?',
+    checkboxLabel: 'Hva liker du?',
+    helpText: 'Skriv når hendelsen skjedde og om det har pågått over lengere periode.',
+    errorMessage: 'Fyll inn dette feltet.'
+  }}
+  argTypes={{
+    title: {control: 'text'},
+    disableCss: {control: 'boolean'}
+  }}
+/>
+
+<Story name="Normal" let:label let:helpText let:radioLabel let:checkboxLabel>
+  <form class="form-layout">
+    <!--    TextInput-->
+    <label class="form-label" for="inputfield">
+      {label}
+    </label>
+
+    {#if helpText}
+      <div class="hint">
+        {@html helpText}
+      </div>
+    {/if}
+
+    <input id="inputfield" name="email" class="form-field" aria-describedby="inputfield-hint inputfield-error" />
+    <!--TextInput end-->
+    <!-- TextArea   -->
+    <label class="form-label" for="inputfield">
+      {label}
+    </label>
+
+    {#if helpText}
+      <div class="hint">
+        {@html helpText}
+      </div>
+    {/if}
+
+    <textarea
+      use:countCharacters
+      maxlength="100"
+      id="inputfield"
+      name="email"
+      class="form-field"
+      aria-describedby="inputfield-hint inputfield-error"
+    />
+    <!--TextArea end-->
+    <!--Radio-->
+    <fieldset id={radioName} aria-describedby={`${radioName}-hint ${radioName}-error`} class="form-fieldset">
+      <legend class="form-legend">{radioLabel}</legend>
+
+      {#if helpText}
+        <div id={`${radioName}-hint`} class="hint">
+          {@html helpText}
+        </div>
+      {/if}
+
+      {#each radioOptions as radio (radio.value)}
+        <div class="form-control radio">
+          <input type="radio" class="input__control" id={radio.value} name={radioName} value={radio.value} />
+
+          <label for={radio.value}>
+            {radio.text}
+          </label>
+        </div>
+      {/each}
+    </fieldset>
+    <!-- Radio end -->
+    <!-- Checkbox -->
+    <fieldset id={checkboxName} aria-describedby={`${checkboxName}-hint ${checkboxName}-error`} class="form-fieldset">
+      <legend class="form-legend">{checkboxLabel}</legend>
+
+      {#if helpText}
+        <div id={`${checkboxName}-hint`} class="hint">
+          {@html helpText}
+        </div>
+      {/if}
+
+      {#each checkBoxOptions as checkbox (checkbox.value)}
+        <div class="form-control checkbox">
+          <input
+            type="checkbox"
+            class="input__control"
+            id={checkbox.value}
+            name={checkboxName}
+            value={checkbox.value}
+          />
+          <label for={checkbox.value}>
+            {checkbox.text}
+          </label>
+        </div>
+      {/each}
+    </fieldset>
+    <!-- Checkbox end-->
+  </form>
+</Story>
+
+<Story name="Input with error" let:label let:helpText let:errorMessage let:radioLabel let:checkboxLabel>
+  <form class="form-layout">
+    <!-- TextInput-->
+    <label class="form-label" for="inputfield">
+      {label}
+    </label>
+
+    {#if helpText}
+      <div class="hint">
+        {@html helpText}
+      </div>
+    {/if}
+
+    <span id="inputfield-error" class="form-error">
+      <span class="inclusively-hidden">Feilmelding:</span>
+      {errorMessage}
+    </span>
+
+    <input
+      id="inputfield"
+      name="email"
+      class="form-field error"
+      aria-invalid="true"
+      aria-describedby="inputfield-hint inputfield-error"
+    />
+    <!-- TextInput end-->
+    <!-- TextArea -->
+    <label class="form-label" for="textfield">
+      {label}
+    </label>
+
+    {#if helpText}
+      <div class="hint">
+        {@html helpText}
+      </div>
+    {/if}
+
+    <span id="textfield-error" class="form-error">
+      <span class="inclusively-hidden">Feilmelding:</span>
+      {errorMessage}
+    </span>
+
+    <textarea
+      id="textfield"
+      name="email"
+      class="form-field error"
+      aria-invalid="true"
+      aria-describedby="textfield-hint textfield-error"
+    />
+    <!-- TextArea end-->
+
+    <!--  Radio -->
+    <fieldset id={radioName} aria-describedby={`${radioName}-hint ${radioName}-error`} class="form-fieldset">
+      <legend class="form-legend">{radioLabel}</legend>
+
+      {#if helpText}
+        <div id={`${radioName}-hint`} class="hint">
+          {@html helpText}
+        </div>
+      {/if}
+
+      <span id="inputfield-error" class="form-error">
+        <span class="inclusively-hidden">Feilmelding:</span>
+        {errorMessage}
+      </span>
+
+      {#each radioOptions as radio (radio.value)}
+        <div class="form-control radio">
+          <input type="radio" class="input__control error" id={radio.value} name={radioName} value={radio.value} />
+
+          <label for={radio.value}>
+            {radio.text}
+          </label>
+        </div>
+      {/each}
+    </fieldset>
+    <!--   Radio end-->
+
+    <!--    Checkbox-->
+    <fieldset
+      id={checkboxName}
+      aria-describedby={`${checkboxName}-hint ${checkboxName}-error`}
+      class="form-fieldset error"
+    >
+      <legend class="form-legend">{checkboxLabel}</legend>
+
+      {#if helpText}
+        <div id={`${checkboxName}-hint`} class="hint">
+          {@html helpText}
+        </div>
+      {/if}
+
+      <span id="inputfield-error" class="form-error">
+        <span class="inclusively-hidden">Feilmelding:</span>
+        {errorMessage}
+      </span>
+
+      {#each checkBoxOptions as checkbox (checkbox.value)}
+        <div class="form-control checkbox">
+          <input
+            type="checkbox"
+            class="input__control error"
+            id={checkbox.value}
+            {checkboxName}
+            value={checkbox.value}
+          />
+          <label for={checkbox.value}>
+            {checkbox.text}
+          </label>
+        </div>
+      {/each}
+    </fieldset>
+    <!--    Checkbox end-->
+  </form>
+</Story>
+
+<style lang="scss" global>
+  @import '../src/scss/app';
+</style>


### PR DESCRIPTION
- add label error style only to checkbox and radio. Remove from input.
- update style on radio and checkbox border. To match Figma
- update style on input error border. To match Figma
- Add story to display all styled inputs

Relates to MT-337