### PR TITLE
Use grid system for Article figure

### DIFF
--- a/src/scss/components/_article.scss
+++ b/src/scss/components/_article.scss
@@ -62,10 +62,6 @@
     > * {
       grid-column: 3 / span 8;
     }
-
-    > figure {
-      grid-column: 2 / span 10;
-    }
   }
 }
 

--- a/stories/components/content/Article.stories.svelte
+++ b/stories/components/content/Article.stories.svelte
@@ -30,7 +30,8 @@
       <div class="intro">
         <p>{intro}</p>
       </div>
-      <figure>
+
+      <figure class="col-2-span-10">
         <img src={imageFile} alt="Alternativ bildetekst" />
         <figcaption>Bildetekst</figcaption>
       </figure>


### PR DESCRIPTION
Remove hard coded styles for <figure> in article.

Relates to: MT-388