### PR TITLE
💄MT-1009 adjust breadcrumbs mobile

### DIFF
--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -3,9 +3,9 @@
 .breadcrumbs {
   font-size: 1rem;
   ol {
-    display: grid;
-    grid-template-columns: max-content max-content max-content 1fr;
-    grid-gap: var(--spacer-xx-small);
+    display: flex;
+    //flex-wrap: wrap;
+    align-items: center;
     padding: 0;
     margin: 0;
     li {
@@ -18,6 +18,9 @@
         white-space: nowrap;
         overflow: hidden;
         display: inline-block;
+      }
+      a::before {
+        margin-right: var(--spacer-xx-small);
       }
     }
     &.expanded {

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -4,23 +4,36 @@
   font-size: 1rem;
   ol {
     display: flex;
-    //flex-wrap: wrap;
     align-items: center;
     padding: 0;
     margin: 0;
     li {
-      display: inline;
+      display: none;
       padding-right: var(--spacer-xx-small);
       font-size: $font-size-small;
       margin-top: 0;
+      &:nth-last-child(2) {
+        display: inline;
+        a::before {
+          transform: rotateY(180deg);
+        }
+      }
       &.ellipsis {
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-        display: inline-block;
       }
       a::before {
         margin-right: var(--spacer-xx-small);
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        display: inline;
+        &:nth-last-child(2) {
+          a::before {
+            transform: rotateY(0);
+          }
+        }
       }
     }
     &.expanded {

--- a/src/svelte/Breadcrumbs.svelte
+++ b/src/svelte/Breadcrumbs.svelte
@@ -109,7 +109,7 @@
 <nav class="breadcrumbs {classNames}" aria-label={ariaLabel}>
   <ol class:expanded={isFull}>
     {#each $state.context.breadcrumbsItems as item, index}
-      <li class:ellipsis={!isFull && index + 1 === $state.context.breadcrumbsItems.length}>
+      <li class:ellipsis={!isFull && index + 1 > 2}>
         {#if index === 0}
           <a href={item.url} rel="external">{homeLabel}</a>
         {:else if item === BUTTON_ELLIPSIS}


### PR DESCRIPTION
On mobile: 
- Only previous breadcrumb should be displayed. Arrow points left. Smaller spacing between arrow and text.

MT-1009, MT-945