### PR TITLE
MTP-1214: fix remove underline on hover menu

### DIFF
--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -71,7 +71,7 @@
       box-shadow: none;
     }
   }
-  button,
+  button.button--link,
   &.button,
   .dropdown-title,
   summary.button {


### PR DESCRIPTION
- only apply hover underline to button link (menu trigger button)