### PR TITLE
Fix CheckboxWithSubSets.test missing parentheses

### DIFF
--- a/src/svelte/components/form/CheckboxWithSubSets.test.ts
+++ b/src/svelte/components/form/CheckboxWithSubSets.test.ts
@@ -178,7 +178,7 @@ describe('Checkbox with subsets', () => {
       legend,
       subCategoryLegend : "Ønsker du å velge bare spesifikke tema?",
       variation: 'secondary'
-    }
+    })
     const legendElement = queryAllByText('Ønsker du å velge bare spesifikke tema?');
     expect(legendElement.length > 0).toEqual(true)
     expect(legendElement[0].parentElement).toHaveClass('checkbox-subsets--secondary')


### PR DESCRIPTION
Why is that parentheses still missing? I thought we fixed it once already.

@lha047 