### PR TITLE
MTP-1681 Fix summarypage anchor breaks

### DIFF
--- a/mt-kit/core/css/src/components/_page-summary.scss
+++ b/mt-kit/core/css/src/components/_page-summary.scss
@@ -21,6 +21,7 @@
     border-bottom: var(--border);
     padding-bottom: var(--heading-padding-bottom);
     align-self: end;
+    word-break: normal;
   }
 
   h3 {


### PR DESCRIPTION
This fixes the issue where the anchor tag with text "Endre" breaks on the summary-step forms.