### PR TITLE
MTP-2006-juster-sokefeltet-slik-at-knappen-vokser-etter-teksten-i-seg

### DIFF
--- a/mt-kit/core/css/src/components/_search.scss
+++ b/mt-kit/core/css/src/components/_search.scss
@@ -12,6 +12,8 @@
 
   button.icon--search-before-primary {
     flex: content;
+    word-break: normal;
+    min-width: auto;
     margin: 0;
     width: auto;
     border-top-left-radius: 0;
@@ -23,6 +25,7 @@
   }
 
   .mt-input[type='search'].hasButton {
+    height: 100%;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-right: 0 none;


### PR DESCRIPTION
![image](https://github.com/Mattilsynet/designsystem/assets/21691168/b6866ef4-850e-497c-b0c3-090fb4994c18)
