### PR TITLE
MTP-2013 fix mixin left padding on text ul

### DIFF
--- a/mt-kit/core/css/src/utilities/_mixins.scss
+++ b/mt-kit/core/css/src/utilities/_mixins.scss
@@ -79,7 +79,7 @@
   > h4 {
     margin-top: var(--spacer-x-small);
   }
-  ul {
+  > ul {
     padding-left: var(--spacer-medium);
     li {
       line-height: 140%;


### PR DESCRIPTION
mixin caused ul nested inside multiselect to have same padding-left