### PR TITLE
MTP-2442 add rule for disclosures used as link, move mt-summary logic

### DIFF
--- a/mt-kit/core/css/src/components/_disclosure.scss
+++ b/mt-kit/core/css/src/components/_disclosure.scss
@@ -15,8 +15,10 @@
   }
 
   .disclosure-header {
-    @include apply-icon($icon: $icon-carret-down-primary, $position: before) {
-      flex-shrink: 0;
+    &:not([href]) {
+      @include apply-icon($icon: $icon-carret-down-primary, $position: before) {
+        flex-shrink: 0;
+      }
     }
     display: flex;
     align-items: center;

--- a/mt-kit/core/css/src/components/_summary-details.scss
+++ b/mt-kit/core/css/src/components/_summary-details.scss
@@ -55,6 +55,7 @@
   .mt-summary {
     @include focus-outline();
     @include apply-icon($icon: $icon-carret-down-primary, $position: before);
+
     display: inline-flex;
     gap: var(--spacer-xxx-small);
     line-height: 140%;
@@ -66,6 +67,13 @@
     }
     &::-webkit-details-marker {
       display: none;
+    }
+    &.mt-summary-icon {
+      @include apply-icon(
+        $icon: $icon-carret-down-primary,
+        $position: before,
+        $spacer: var(--spacer-xxx-small)
+      );
     }
   }
   &[open] {

--- a/mt-kit/core/css/src/components/_summary-details.scss
+++ b/mt-kit/core/css/src/components/_summary-details.scss
@@ -56,6 +56,7 @@
     @include focus-outline();
 
     display: inline-flex;
+    align-items: center;
     gap: var(--spacer-xxx-small);
     line-height: 140%;
     color: var(--mt-button-neutral-border);

--- a/mt-kit/core/css/src/components/_summary-details.scss
+++ b/mt-kit/core/css/src/components/_summary-details.scss
@@ -54,7 +54,6 @@
 
   .mt-summary {
     @include focus-outline();
-    @include apply-icon($icon: $icon-carret-down-primary, $position: before);
 
     display: inline-flex;
     gap: var(--spacer-xxx-small);
@@ -69,11 +68,7 @@
       display: none;
     }
     &.mt-summary-icon {
-      @include apply-icon(
-        $icon: $icon-carret-down-primary,
-        $position: before,
-        $spacer: var(--spacer-xxx-small)
-      );
+      @include apply-icon($icon: $icon-carret-down-primary, $position: before);
     }
   }
   &[open] {

--- a/mt-kit/core/svelte/src/lib/svelte/components/SummaryDetail.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/components/SummaryDetail.svelte
@@ -22,7 +22,7 @@
   aria-labelledby={ariaLabelledBy}
   data-test-id={testId}
   bind:open={isOpen}>
-  <summary class="mt-summary {summaryClass}">{@html title}</summary>
+  <summary class="mt-summary mt-summary-icon {summaryClass}">{@html title}</summary>
   <div class="summary-wrapper {summaryWrapperClass}">
     <slot />
   </div>


### PR DESCRIPTION
:not([href]) check before using mixing on .disclosure-header, to exclude if it is a link

Add extra class to not cause issue for other places mt-summary is used

Mixin is moved from:
.mt-summary -> &.mt-summary-icon