### PR TITLE
MTP-2461 text-decoration not use shorthand to support Safari

### DIFF
--- a/mt-kit/core/css/src/global/_links.scss
+++ b/mt-kit/core/css/src/global/_links.scss
@@ -21,8 +21,11 @@ a {
   padding: var(--border-width-regular);
   line-height: 1.75rem;
   min-width: $minimum-click-width;
-  text-decoration: $color-link-underline underline $border-width-regular;
+  text-decoration-line: underline;
+  text-decoration-color: $color-link-underline;
+  text-decoration-thickness: $border-width-regular;
   text-underline-offset: $spacer-xxx-small;
+  text-decoration-skip-ink: auto;
 
   &.inline-flex {
     display: inline-flex;
@@ -34,6 +37,7 @@ a {
   &:hover {
     text-decoration-thickness: $border-width-medium;
   }
+
   &:focus {
     box-shadow: $focus-box-shadow-no-outline;
   }

--- a/mt-kit/core/css/src/utilities/_layout.scss
+++ b/mt-kit/core/css/src/utilities/_layout.scss
@@ -305,15 +305,19 @@ Only use if it does NOT affect accessibility
     justify-self: center;
     gap: var(--spacer-medium);
     a {
+      @include apply-external-link-icon($icon: $icon-external-link-on-dark, $position: before);
       color: var(--mt-footer-links-color);
-      text-decoration: var(--mt-footer-color) underline $border-width-regular;
-      &:focus {
-        box-shadow: 0 0 0 0.25rem var(--mt-footer-color);
-      }
+      text-decoration-line: underline;
+      text-decoration-color: var(--mt-footer-color);
+      text-decoration-thickness: $border-width-regular;
+
       &:hover {
         text-decoration-thickness: $border-width-medium;
       }
-      @include apply-external-link-icon($icon: $icon-external-link-on-dark, $position: before);
+
+      &:focus {
+        box-shadow: 0 0 0 0.25rem var(--mt-footer-color);
+      }
     }
   }
 


### PR DESCRIPTION
Fix for: Links on Safari doesnt have underline