### PR TITLE
MTP-2462 Remove keywords fallback on MenupointsIcons

### DIFF
--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={toKebabCase(menuPoint?.keywords ? menuPoint.keywords : menuPoint.text)}
+        aria-describedby={toKebabCase(menuPoint?.keywords ? menuPoint.keywords : '')}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={toKebabCase(menuPoint?.keywords ? menuPoint.keywords : '')}
+        aria-describedby={menuPoint?.keywords ? toKebabCase(menuPoint?.keywords) : ''}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={menuPoint.keywords ? toKebabCase(menuPoint?.keywords) : ''}
+        aria-describedby={menuPoint.keywords ? toKebabCase(menuPoint.keywords) : ''}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={toKebabCase(menuPoint.keywords)}
+        aria-describedby={toKebabCase(menuPoint.keywords ?? menuPoint.text)}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">
@@ -36,7 +36,7 @@
         <HeadingLevel class="mt-h3 menu-point-heading" headingLevel={+headerTag.charAt(1)}
           >{@html menuPoint.text}</HeadingLevel>
 
-        {#if menuPoint.showKeywords}
+        {#if menuPoint.keywords}
           <p id={toKebabCase(menuPoint.keywords)}>
             {@html menuPoint.keywords}
           </p>

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={menuPoint?.keywords ? toKebabCase(menuPoint?.keywords) : ''}
+        aria-describedby={menuPoint.keywords ? toKebabCase(menuPoint?.keywords) : ''}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -36,9 +36,11 @@
         <HeadingLevel class="mt-h3 menu-point-heading" headingLevel={+headerTag.charAt(1)}
           >{@html menuPoint.text}</HeadingLevel>
 
-        <p id={toKebabCase(menuPoint.keywords)}>
-          {@html menuPoint.keywords}
-        </p>
+        {#if menuPoint.showKeywords}
+          <p id={toKebabCase(menuPoint.keywords)}>
+            {@html menuPoint.keywords}
+          </p>
+        {/if}
       </a>
     </li>
   {/each}

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={toKebabCase(menuPoint.keywords ?? menuPoint.text)}
+        aria-describedby={toKebabCase(menuPoint.keywords ? menuPoint.keywords : menuPoint.text)}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.svelte
@@ -19,7 +19,7 @@
         href={menuPoint.url}
         rel={mapRelExternal(menuPoint.url)}
         class="menu-point border-radius p-xs"
-        aria-describedby={toKebabCase(menuPoint.keywords ? menuPoint.keywords : menuPoint.text)}
+        aria-describedby={toKebabCase(menuPoint?.keywords ? menuPoint.keywords : menuPoint.text)}
         data-testid="menupoints-link">
         {#if menuPoint.iconResource}
           <div class="svg-wrapper" aria-hidden="true">

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.test.ts
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.test.ts
@@ -29,7 +29,7 @@ describe('Menu points with icons', () => {
         {
           iconResource: undefined,
           icon: 'icon src',
-          keywords: '',
+          keywords: null,
           text: ''
         }
       ]

--- a/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.test.ts
+++ b/mt-kit/core/svelte/src/lib/svelte/content/MenuPointsIcons.test.ts
@@ -29,7 +29,8 @@ describe('Menu points with icons', () => {
         {
           iconResource: undefined,
           icon: 'icon src',
-          keywords: ''
+          keywords: '',
+          text: ''
         }
       ]
     }

--- a/mt-kit/core/svelte/src/lib/ts/types.d.ts
+++ b/mt-kit/core/svelte/src/lib/ts/types.d.ts
@@ -195,5 +195,5 @@ export interface MenuPoint {
   url: string
   icon: string
   text: string
-  keywords?: string | undefined
+  keywords?: string | null
 }

--- a/mt-kit/core/svelte/src/lib/ts/types.d.ts
+++ b/mt-kit/core/svelte/src/lib/ts/types.d.ts
@@ -195,5 +195,5 @@ export interface MenuPoint {
   url: string
   icon: string
   text: string
-  keywords?: string | null
+  keywords?: string
 }

--- a/mt-kit/core/svelte/src/lib/ts/types.d.ts
+++ b/mt-kit/core/svelte/src/lib/ts/types.d.ts
@@ -196,4 +196,5 @@ export interface MenuPoint {
   icon: string
   text: string
   keywords: string
+  showKeywords: boolean
 }

--- a/mt-kit/core/svelte/src/lib/ts/types.d.ts
+++ b/mt-kit/core/svelte/src/lib/ts/types.d.ts
@@ -195,6 +195,5 @@ export interface MenuPoint {
   url: string
   icon: string
   text: string
-  keywords: string
-  showKeywords: boolean
+  keywords?: string | undefined
 }

--- a/mt-kit/core/svelte/src/stories/nettlosninger/MenuPoints.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/nettlosninger/MenuPoints.stories.svelte
@@ -32,7 +32,7 @@
       {
         text: 'Mat',
         url: '',
-        keywords: '',
+        keywords: null,
         iconResource: foodSvg
       },
       {

--- a/mt-kit/core/svelte/src/stories/nettlosninger/MenuPoints.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/nettlosninger/MenuPoints.stories.svelte
@@ -31,8 +31,8 @@
       },
       {
         text: 'Mat',
-        url: '#',
-        keywords: 'Merking, produksjon, smitte, matservering, import og eksport',
+        url: '',
+        keywords: '',
         iconResource: foodSvg
       },
       {


### PR DESCRIPTION
Changes: Remove the themepage intro as fallback.
Results: If themepage has no keywords added, then nothing will show on the MenuPoint Card (link to themepage)