### PR TITLE
MTP-2495: fix summary layout summary

### DIFF
--- a/mt-kit/core/css/src/components/_page-summary.scss
+++ b/mt-kit/core/css/src/components/_page-summary.scss
@@ -7,7 +7,7 @@
 
   display: grid;
   grid-template-areas: 'heading change .';
-  grid-template-columns: max-content max-content 1fr;
+  grid-template-columns: auto max-content 1fr;
   column-gap: var(--gap);
   margin-top: var(--spacer-x-small);
 


### PR DESCRIPTION
- fix content "outside" layout
- From this ![Screenshot 2024-09-13 at 14 30 55](https://github.com/user-attachments/assets/95bf9fd5-2736-4424-a762-cba5c36e78f0)
- to this
![Screenshot 2024-09-13 at 14 30 36](https://github.com/user-attachments/assets/d8b14a0c-dcb7-4e82-b4d3-042ce4822cbb)
![Screenshot 2024-09-13 at 14 30 30](https://github.com/user-attachments/assets/fe3cc6a7-9c7f-4ebe-87b2-449c7ce989b1)

