### PR TITLE
MTP-2651: remove special styling on card-article intro

### DIFF
--- a/mt-kit/core/css/src/utilities/_mixins.scss
+++ b/mt-kit/core/css/src/utilities/_mixins.scss
@@ -100,10 +100,6 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
-  .intro {
-    font-size: $font-size-body;
-    font-style: italic;
-  }
 
   .text {
     @include xp-html-area;


### PR DESCRIPTION
- content designers say we should not use italic for this.