### PR TITLE
MTP-2629: rename slot headers to header #minor

### DIFF
--- a/mt-kit/core/svelte/src/lib/svelte/components/Table.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/components/Table.svelte
@@ -17,7 +17,7 @@
   <thead class="mt-thead">
     <tr class="mt-tr">
       {#each headers as header}
-        <slot name="headers" {header} />
+        <slot name="header" {header} />
       {/each}
     </tr>
   </thead>

--- a/mt-kit/core/svelte/src/lib/svelte/components/Table.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/components/Table.svelte
@@ -17,13 +17,13 @@
   <thead class="mt-thead">
     <tr class="mt-tr">
       {#each headers as header}
-        <slot name="header" {header} />
+        <slot name="headersSlot" {header} />
       {/each}
     </tr>
   </thead>
   <tbody class="mt-tbody">
     {#each rows as row}
-      <slot name="row" {row} />
+      <slot name="rowSlot" {row} />
     {/each}
   </tbody>
 </table>


### PR DESCRIPTION
- cant have same name as component prop in svelte 5