### PR TITLE
MTP-2803 Refactored loadJs check in CheckboxWithSubSets

### DIFF
--- a/mt-kit/core/svelte/src/lib/svelte/components/form/CheckboxWithSubSets.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/components/form/CheckboxWithSubSets.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { slide } from 'svelte/transition'
-  import { onMount } from 'svelte'
   import type { CheckboxWithSubSectionsOptions } from '$lib/ts'
   import { interpolate } from '$lib/ts'
 
@@ -17,6 +16,7 @@
     level3Legend?: string
     helpText?: string
     border?: boolean
+    loadJs?: boolean
   }
 
   let {
@@ -31,18 +31,13 @@
     level2Legend = ``,
     level3Legend = ``,
     helpText,
-    border = true
+    border = true,
+    loadJs = false
   }: Props = $props()
 
   let fieldsetClass = $derived(
     variation === 'primary' ? 'checkbox-subsets--primary' : 'checkbox-subsets--secondary'
   )
-
-  let hasJS = $state(false)
-
-  onMount(() => {
-    hasJS = true
-  })
 
   function mainCategory(mainIndex: number): void {
     // Uncheck all subcategories if parent main category is unchecked
@@ -82,7 +77,7 @@
   {#if helpText}
     <p class="hint">{helpText}</p>
   {/if}
-  {#if (hasJS && hasCheckAll) || forceCheckAll}
+  {#if (loadJs && hasCheckAll) || forceCheckAll}
     <div class="form-control checkbox-subsets">
       <input
         id={`${optionsName}-${options.key}`}
@@ -112,7 +107,7 @@
         {formatLabel(listItem.displayName, listItem.docCount)}
       </label>
     </div>
-    {#if (!hasJS || listItem.checked) && listItem.children && listItem.children.length > 0}
+    {#if (!loadJs || listItem.checked) && listItem.children && listItem.children.length > 0}
       <fieldset
         class={`mt-fieldset checkbox checkbox-subsets ${fieldsetClass}`}
         transition:slide={{ axis: 'y', duration: 200 }}>
@@ -137,7 +132,7 @@
               {formatLabel(subListItem.displayName, subListItem.docCount)}
             </label>
           </div>
-          {#if subListItem.checked && subListItem.children && subListItem.children.length > 0}
+          {#if (!loadJs || subListItem.checked) && subListItem.children && subListItem.children.length > 0}
             <fieldset
               class={'mt-fieldset checkbox checkbox-subsets--secondary'}
               transition:slide={{ axis: 'y', duration: 200 }}>

--- a/mt-kit/core/svelte/src/lib/svelte/components/form/CheckboxWithSubSets.test.ts
+++ b/mt-kit/core/svelte/src/lib/svelte/components/form/CheckboxWithSubSets.test.ts
@@ -76,7 +76,8 @@ describe('Checkbox with subsets', () => {
     const { getByText, getByLabelText, queryByText } = render(CheckboxWithSubSets, {
       options: { children: addChecked(['dyr'], options) },
       level1Legend,
-      transitionSlide: { y: 200, duration: 0 }
+      transitionSlide: { y: 200, duration: 0 },
+      loadJs: true
     })
     expect(getByText(level1Legend)).toBeInTheDocument()
     expect(getByText(`${options[0].displayName} (${options[0].docCount})`)).toBeInTheDocument()
@@ -106,7 +107,8 @@ describe('Checkbox with subsets', () => {
   test('Renders subsets of checkboxes', async () => {
     const { getByText, getByLabelText, queryByText } = render(CheckboxWithSubSets, {
       options: { children: addChecked(['dyr'], options) },
-      level1Legend
+      level1Legend,
+      loadJs: true
     })
     expect(getByText(`${options[0].displayName} (${options[0].docCount})`)).toBeInTheDocument()
     const animal = getByLabelText(`${options[0].displayName} (${options[0].docCount})`)
@@ -125,7 +127,8 @@ describe('Checkbox with subsets', () => {
     const { getByLabelText } = render(CheckboxWithSubSets, {
       options: { children: addChecked(['dyr', 'dyr/produksjonsdyr'], options) },
       level1Legend,
-      optionsName
+      optionsName,
+      loadJs: true
     })
     const mainCategory = getByLabelText(`${options[0].displayName} (${options[0].docCount})`)
     expect(mainCategory).toBeChecked()
@@ -144,7 +147,8 @@ describe('Checkbox with subsets', () => {
   test('Test that subcategories are unchecked when main category is unchecked', async () => {
     const { getByLabelText, queryByLabelText } = render(CheckboxWithSubSets, {
       options: { children: addChecked(['dyr', 'dyr/produksjonsdyr'], options) },
-      level1Legend
+      level1Legend,
+      loadJs: true
     })
 
     const mainCategoryCheckbox = getByLabelText(
@@ -188,7 +192,8 @@ describe('Checkbox with subsets', () => {
       options: { children: addChecked(['dyr'], options) },
       level1Legend,
       level2Legend: 'Ønsker du å velge bare spesifikke tema?',
-      variation: 'secondary'
+      variation: 'secondary',
+      loadJs: true
     })
     const legendElement = queryAllByText('Ønsker du å velge bare spesifikke tema?')
     expect(legendElement.length > 0).toEqual(true)
@@ -202,7 +207,8 @@ describe('Checkbox with subsets', () => {
       level2Legend: 'Ønsker du å velge bare spesifikke tema?',
       variation: 'secondary',
       hasCheckAll: true,
-      checkAllLabel: 'Velg alle'
+      checkAllLabel: 'Velg alle',
+      loadJs: true
     })
     const selectAll = getByLabelText('Velg alle')
     expect(selectAll).toBeInTheDocument()
@@ -240,7 +246,8 @@ describe('Checkbox with subsets', () => {
       level2Legend: 'Ønsker du å velge bare spesifikke tema?',
       variation: 'secondary',
       hasCheckAll: true,
-      checkAllLabel: 'Velg alle'
+      checkAllLabel: 'Velg alle',
+      loadJs: true
     })
 
     const checkAll = getByLabelText('Velg alle')
@@ -265,7 +272,8 @@ describe('Checkbox with subsets', () => {
       level2Legend: 'Ønsker du å velge bare spesifikke tema?',
       variation: 'secondary',
       hasCheckAll: true,
-      checkAllLabel: 'Velg alle'
+      checkAllLabel: 'Velg alle',
+      loadJs: true
     })
 
     const checkAll = getByLabelText('Velg alle')
@@ -300,7 +308,8 @@ describe('Checkbox with subsets', () => {
       level2Legend: 'Ønsker du å velge bare spesifikke tema?',
       variation: 'secondary',
       hasCheckAll: true,
-      checkAllLabel: 'Velg alle'
+      checkAllLabel: 'Velg alle',
+      loadJs: true
     })
 
     const checkAll = getByLabelText('Velg alle')
@@ -321,7 +330,8 @@ describe('Checkbox with subsets', () => {
       variation: 'secondary',
       hasCheckAll: true,
       checkAllLabel: 'Velg alle',
-      checkAllValue: 'all'
+      checkAllValue: 'all',
+      loadJs: true
     })
     const checkAll = getByLabelText('Velg alle')
     expect(checkAll).not.toBeChecked()

--- a/mt-kit/core/svelte/src/stories/form/CheckboxWithSubSets.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/form/CheckboxWithSubSets.stories.svelte
@@ -5,81 +5,83 @@
   import { wrapInShadowDom } from '../storybook-utils/utils'
   import { interpolate, toKebabCase } from '$lib/ts/utils'
 
+  let options = $state({
+    key: 'all',
+    children: [
+      {
+        key: 'dyr',
+        displayName: 'Dyr asdflaksjdf alksadfjklfdasjkfds  sdaff ads asd kaldsfjs',
+        docCount: 49,
+        children: [
+          {
+            key: 'produksjonsdyr',
+            displayName: 'Produksjonsdyr',
+            docCount: 38,
+            children: []
+          },
+          {
+            key: 'dyresykdommer',
+            displayName: 'Dyresykdommer asdfasd asdfjas asd asdf afdasdfasdfdsdasdf',
+            docCount: 2,
+            children: []
+          },
+          {
+            key: 'kjaeledyr',
+            displayName: 'Kjæledyr',
+            docCount: 1,
+            children: []
+          }
+        ]
+      },
+      {
+        key: 'fisk-og-akvakultur',
+        displayName: 'Fisk og akvakultur',
+        docCount: 1,
+        children: [
+          {
+            key: 'fiskesykdommer',
+            displayName: 'Fiskesykdommer',
+            docCount: 1,
+            children: []
+          }
+        ]
+      },
+      {
+        key: 'mat',
+        displayName: 'Mat',
+        docCount: 3,
+        children: [
+          {
+            key: 'import-av-mat',
+            displayName: 'Import av mat',
+            docCount: 1,
+            children: [
+              {
+                key: 'kommersiell-import',
+                displayName: 'Kommersiell import',
+                docCount: 1,
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        key: 'kosmetikk',
+        displayName: 'Kosmetikk',
+        docCount: 1,
+        children: []
+      }
+    ]
+  })
+
   const { Story } = defineMeta({
     title: 'Components/Form/CheckboxWithSubsets',
     args: {
       disableCss: false,
       legend: 'Tema',
       variation: 'primary',
-      options: {
-        key: 'all',
-        children: [
-          {
-            key: 'dyr',
-            displayName: 'Dyr asdflaksjdf alksadfjklfdasjkfds  sdaff ads asd kaldsfjs',
-            docCount: 49,
-            children: [
-              {
-                key: 'produksjonsdyr',
-                displayName: 'Produksjonsdyr',
-                docCount: 38,
-                children: []
-              },
-              {
-                key: 'dyresykdommer',
-                displayName: 'Dyresykdommer asdfasd asdfjas asd asdf afdasdfasdfdsdasdf',
-                docCount: 2,
-                children: []
-              },
-              {
-                key: 'kjaeledyr',
-                displayName: 'Kjæledyr',
-                docCount: 1,
-                children: []
-              }
-            ]
-          },
-          {
-            key: 'fisk-og-akvakultur',
-            displayName: 'Fisk og akvakultur',
-            docCount: 1,
-            children: [
-              {
-                key: 'fiskesykdommer',
-                displayName: 'Fiskesykdommer',
-                docCount: 1,
-                children: []
-              }
-            ]
-          },
-          {
-            key: 'mat',
-            displayName: 'Mat',
-            docCount: 3,
-            children: [
-              {
-                key: 'import-av-mat',
-                displayName: 'Import av mat',
-                docCount: 1,
-                children: [
-                  {
-                    key: 'kommersiell-import',
-                    displayName: 'Kommersiell import',
-                    docCount: 1,
-                    children: []
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            key: 'kosmetikk',
-            displayName: 'Kosmetikk',
-            docCount: 1,
-            children: []
-          }
-        ]
-      },
+      options: options,
       optionsWithoutDocCount: {
         key: 'all2',
         children: [
@@ -189,7 +191,6 @@
   {#snippet children({
     disableJs,
     legend,
-    options,
     disableCss,
     variation,
     optionsWithoutDocCount,
@@ -205,10 +206,11 @@
         <form class="mt-form">
           <CheckboxWithSubSets
             helpText="Velg et tema"
-            {options}
+            bind:options
             {variation}
             level1Legend={legend}
-            level2Legend={`${legend} i `} />
+            level2Legend={`${legend} i `}
+            loadJs={!disableJs} />
         </form>
         <h2 class="mt-h2">Nested checkboxes without doc count and border</h2>
         <p>User variation="primary" (default) when checkboxes stand alone</p>
@@ -218,14 +220,16 @@
             {variation}
             level1Legend="Tema uten antall"
             {border}
-            level2Legend={`${legend} i `} />
+            level2Legend={`${legend} i `}
+            loadJs={!disableJs} />
           <h2 class="mt-h3">Variation = secondary</h2>
           <CheckboxWithSubSets
             options={optionsWithoutDocCount}
             variation="secondary"
             level1Legend="legend 1"
             level2Legend="legend 2"
-            {border} />
+            {border}
+            loadJs={!disableJs} />
         </form>
         <h2 class="mt-h2">Nestede checkboxet inside disclosure</h2>
         <p>
@@ -244,10 +248,39 @@
               options={disclosureOptions}
               hasCheckAll={true}
               checkAllLabel={disclosure.checkAllLabel}
-              level1Legend={interpolate(disclosure.level1Legend, [
-                disclosure.title.toLowerCase()
-              ])} />
+              level1Legend={interpolate(disclosure.level1Legend, [disclosure.title.toLowerCase()])}
+              loadJs={!disableJs} />
           </Disclosure>
+        </form>
+      </section>
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Without JS">
+  {#snippet children({
+    disableJs,
+    legend,
+    options,
+    disableCss,
+    variation,
+    optionsWithoutDocCount,
+    border,
+    disclosure,
+    disclosureOptions
+  })}
+    <div class="container layout-grid layout-grid--column-12" use:wrapInShadowDom={disableCss}>
+      <section class="article-page col-1-span-12">
+        <h1 class="mt-h1">Nested checkbox</h1>
+        <h2 class="mt-h2">Nested checkbox without JS</h2>
+        <form class="mt-form">
+          <CheckboxWithSubSets
+            loadJs={false}
+            helpText="Velg et tema"
+            {options}
+            {variation}
+            level1Legend={legend}
+            level2Legend={`${legend} i `} />
         </form>
       </section>
     </div>

--- a/mt-kit/core/svelte/src/stories/form/CheckboxWithSubSets.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/form/CheckboxWithSubSets.stories.svelte
@@ -79,6 +79,7 @@
     title: 'Components/Form/CheckboxWithSubsets',
     args: {
       disableCss: false,
+      disableJs: false,
       legend: 'Tema',
       variation: 'primary',
       options: options,
@@ -179,6 +180,7 @@
     },
     argTypes: {
       disableCss: { control: 'boolean' },
+      disableJs: { control: 'boolean' },
       variation: {
         options: ['primary', 'secondary'],
         control: 'radio'
@@ -251,36 +253,6 @@
               level1Legend={interpolate(disclosure.level1Legend, [disclosure.title.toLowerCase()])}
               loadJs={!disableJs} />
           </Disclosure>
-        </form>
-      </section>
-    </div>
-  {/snippet}
-</Story>
-
-<Story name="Without JS">
-  {#snippet children({
-    disableJs,
-    legend,
-    options,
-    disableCss,
-    variation,
-    optionsWithoutDocCount,
-    border,
-    disclosure,
-    disclosureOptions
-  })}
-    <div class="container layout-grid layout-grid--column-12" use:wrapInShadowDom={disableCss}>
-      <section class="article-page col-1-span-12">
-        <h1 class="mt-h1">Nested checkbox</h1>
-        <h2 class="mt-h2">Nested checkbox without JS</h2>
-        <form class="mt-form">
-          <CheckboxWithSubSets
-            loadJs={false}
-            helpText="Velg et tema"
-            {options}
-            {variation}
-            level1Legend={legend}
-            level2Legend={`${legend} i `} />
         </form>
       </section>
     </div>


### PR DESCRIPTION
Also fixed error with 3rd level options children: when no js is loaded they weren't shown until click, but should be permanently shown just like level 1 and 2