### PR TITLE
MTP-2803 config to include component prop types in package

### DIFF
--- a/mt-kit/core/svelte/package-lock.json
+++ b/mt-kit/core/svelte/package-lock.json
@@ -63,6 +63,9 @@
       "engines": {
         "node": ">= 18.18.0",
         "npm": ">= 9.5.1"
+      },
+      "peerDependencies": {
+        "svelte": "^5.14.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/mt-kit/core/svelte/package.json
+++ b/mt-kit/core/svelte/package.json
@@ -98,5 +98,8 @@
     "@u-elements/u-datalist": "^0.0.9",
     "gh-pages": "^5.0.0",
     "ol": "^8.2.0"
+  },
+  "peerDependencies": {
+    "svelte": "^5.14.4"
   }
 }


### PR DESCRIPTION
Apparently svelte > 5 is needed as a peerDependency, for component prop type info to be included in the published package. Ref https://github.com/sveltejs/kit/issues/12972

With this, the web-project "sees" what type of props the designsystem components have and should have, eliminating the lint errors of type "xxx is not assignable to type never"