### PR TITLE
fix(MTP-2782): use text color granskog and font mattilsynet sans

### DIFF
--- a/mt-kit/core/css/src/_color-tokens-new.scss
+++ b/mt-kit/core/css/src/_color-tokens-new.scss
@@ -37,7 +37,7 @@
   --color-on-mt-blue-medium: #{$color-on-mt-blue-medium};
   --color-secondary: #{$color-secondary};
   --color-on-secondary: #{$color-on-secondary};
-  --color-mt-text-dark: #{$color-mt-granskog-dark};
+  --color-mt-text-dark: #{$color-mt-granskog};
   --color-on-mt-text-dark: #{$color-on-mt-text-dark};
   --color-error: #{$color-mt-rognebaer-contrast};
   --color-on-error: #{$color-on-error};

--- a/mt-kit/core/css/src/_reset.scss
+++ b/mt-kit/core/css/src/_reset.scss
@@ -53,8 +53,6 @@ html:focus-within {
 /* Set core body defaults */
 .mt-body {
   min-height: 100vh;
-  font-family: system-ui, sans-serif;
-  text-rendering: optimizeSpeed;
 }
 
 // 🟣 Only update for content flow elements

--- a/mt-kit/core/css/src/_theme.scss
+++ b/mt-kit/core/css/src/_theme.scss
@@ -36,7 +36,6 @@ $color-grey-hue: $color-primary !default;
 $color-background-body: color.scale($color-grey-hue, $lightness: 98%) !default;
 $color-grey-hue: color.channel($color-grey-hue, 'hue', $space: hsl);
 
-$font-family: Helvetica, Arial, sans-serif !default;
 $font-weight-light: 300 !default;
 $font-weight-normal: 400 !default;
 $font-weight-medium: 500 !default;

--- a/mt-kit/core/css/src/app.scss
+++ b/mt-kit/core/css/src/app.scss
@@ -1,4 +1,3 @@
-@use 'fonts';
 @use 'reset';
 @use 'theme';
 @use 'global';

--- a/mt-kit/core/css/src/global/_body.scss
+++ b/mt-kit/core/css/src/global/_body.scss
@@ -460,9 +460,6 @@
   display: grid;
   grid-template-rows: auto 1fr auto;
   row-gap: 0;
-  background-color: var(--body-background);
-  color: var(--body-color);
-  font-family: $font-family;
   font-size: $font-size-body;
 
   .layout-with-sidebar {

--- a/mt-kit/core/svelte/package.json
+++ b/mt-kit/core/svelte/package.json
@@ -102,5 +102,6 @@
   },
   "peerDependencies": {
     "svelte": "^5.14.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/mt-kit/core/svelte/package.json
+++ b/mt-kit/core/svelte/package.json
@@ -102,6 +102,5 @@
   },
   "peerDependencies": {
     "svelte": "^5.14.4"
-  },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  }
 }


### PR DESCRIPTION
- ✅ Tiny cleanup of empty `_fonts.scss` file
- ✅ Letting `@mattilsynet/design` set font-family, background and color
- ✅ Keeping local `color-mt-text-dark` for now as it is used in several components
- 🤔 Question: There is a `data-theme="green"`, but from what I can see, it is only used once; is this something we should just move into `mt-body` maybe? 