### PR TITLE
MTP-2978 radio input

### DIFF
--- a/mt-kit/core/svelte/src/lib/svelte/components/form/RadioGroup.svelte
+++ b/mt-kit/core/svelte/src/lib/svelte/components/form/RadioGroup.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import InputError from './InputErrorMessage.svelte'
   import Tag from '../Tag.svelte'
   import type { ErrorDetail } from '$lib/ts'
-  import { createInputAriaDescribedby, toKebabCase } from '$lib/ts'
+  import { toKebabCase } from '$lib/ts'
   import { tick } from 'svelte'
+  import { styles } from '@mattilsynet/design'
 
   interface Props {
     value?: string
@@ -17,7 +17,6 @@
     textOptional?: string
     showOptionalText?: boolean
     hiddenErrorText?: string
-    theme?: 'radio' | 'button'
   }
 
   let {
@@ -30,9 +29,7 @@
     options = [],
     isRequired,
     textOptional = '(valgfritt felt)',
-    showOptionalText = true,
-    hiddenErrorText,
-    theme = 'radio'
+    showOptionalText = true
   }: Props = $props()
   let isInitialized = false
 
@@ -46,15 +43,8 @@
   })
 </script>
 
-<fieldset
-  id={name}
-  role="radiogroup"
-  aria-required={isRequired}
-  aria-describedby={createInputAriaDescribedby(helpText ? name : undefined, error)}
-  class="mt-fieldset form-fieldset {theme === 'radio' ? 'radio' : ''} {theme === 'button'
-    ? 'mt-button-radio'
-    : ''} {className}">
-  <legend class="mt-legend form-legend">
+<fieldset class="{styles.fieldset} {className}" data-size="md" data-required="hidden">
+  <legend>
     {label}
     {#if !isRequired && showOptionalText}
       <Tag data-icon={false} data-color="info">{textOptional}</Tag>
@@ -62,30 +52,27 @@
   </legend>
 
   {#if helpText}
-    <div id={`${name}-hint`} class="hint">
+    <p>
       {@html helpText}
-    </div>
+    </p>
   {/if}
 
   {#if error}
-    <InputError {...error} {hiddenErrorText} />
+    <div class={styles.validation}>{error.message}</div>
   {/if}
 
   {#each options as radio (radio.value)}
-    <div class="form-control">
+    <div class={styles.field}>
       <input
         type="radio"
         id={`${name}-${toKebabCase(radio.value)}`}
         {name}
-        class="mt-input input__control"
-        class:error
+        class={styles.input}
         bind:group={value}
         value={radio.value}
-        aria-describedby={createInputAriaDescribedby(helpText ? name : undefined, error)}
+        aria-required={isRequired}
         checked={value === radio.value} />
-      <label
-        class="mt-label {theme === 'button' ? 'mt-button mt-button--secondary' : ''}"
-        for={`${name}-${toKebabCase(radio.value)}`}>
+      <label for={`${name}-${toKebabCase(radio.value)}`}>
         {radio.text}
       </label>
     </div>

--- a/mt-kit/core/svelte/src/lib/svelte/components/form/RadioGroup.test.ts
+++ b/mt-kit/core/svelte/src/lib/svelte/components/form/RadioGroup.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/svelte'
+import { render } from '@testing-library/svelte'
 import RadioGroup from './RadioGroup.svelte'
 
 describe('RadioGroup', () => {
@@ -17,7 +17,7 @@ describe('RadioGroup', () => {
   }
   const error = undefined
   test('Renders', () => {
-    const { getByLabelText, getByDisplayValue, getByText, getByRole } = render(RadioGroup, {
+    const { getByLabelText, getByDisplayValue, getByText } = render(RadioGroup, {
       value: value,
       error,
       name,
@@ -37,38 +37,6 @@ describe('RadioGroup', () => {
     const input = getByDisplayValue(value)
     expect(input).toBeInTheDocument()
     expect(input.checked).toEqual(true)
-    const fieldSet = getByRole('radiogroup')
-    expect(fieldSet?.getAttribute('aria-required')).toEqual('true')
-    expect(fieldSet?.getAttribute('aria-describedby')).toEqual('name-hint')
-  })
-
-  test('Renders with button theme', async () => {
-    const { getByLabelText, getByDisplayValue, getByText, getByRole } = render(RadioGroup, {
-      value,
-      name,
-      label: yesLabel,
-      helpText,
-      options,
-      isRequired: !!properties.validationRequired,
-      theme: 'button'
-    })
-    expect(getByText(helpText)).toBeInTheDocument()
-    expect(getByLabelText(options[0].text)).toBeInTheDocument()
-    expect(getByLabelText(options[1].text)).toBeInTheDocument()
-    const input = getByDisplayValue(value)
-    expect(input).toBeInTheDocument()
-    const fieldSet = getByRole('radiogroup')
-    expect(fieldSet?.getAttribute('aria-required')).toEqual('true')
-    const label2 = getByLabelText(options[1].text)
-    await fireEvent.click(label2)
-    const label2AfterClick = getByLabelText(options[1].text)
-    expect(label2AfterClick.checked).toEqual(true)
-
-    const label1 = getByLabelText(options[0].text)
-    await fireEvent.click(label1)
-    const label1AfterClick = getByLabelText(options[0].text)
-    expect(label1AfterClick.checked).toEqual(true)
-    expect(label2AfterClick.checked).toEqual(false)
   })
 
   test('Renders optional in label if not required', () => {
@@ -82,13 +50,13 @@ describe('RadioGroup', () => {
       options
     })
     expect(getByText(/valgfritt felt/)).toBeInTheDocument()
-    const fieldSet = getByRole('radiogroup')
+    const fieldSet = getByRole('group')
     expect(fieldSet).not.toHaveAttribute('aria-required')
   })
 
   test('Renders error', () => {
     const err = { fieldName: name, message: 'This is the errormessage' }
-    const { getByText, getByRole } = render(RadioGroup, {
+    const { getByText } = render(RadioGroup, {
       value,
       error: err,
       name,
@@ -97,8 +65,6 @@ describe('RadioGroup', () => {
       options
     })
     expect(getByText(/This is the errormessage/)).toBeInTheDocument()
-    const fieldSet = getByRole('radio', { name: 'Ja' })
-    expect(fieldSet.getAttribute('aria-describedby')).toEqual('name-hint name-error')
   })
 
   test('Renders without helptext', () => {

--- a/mt-kit/core/svelte/src/stories/form/RadioButtons.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/form/RadioButtons.stories.svelte
@@ -63,19 +63,7 @@
           {helpText}
           {label}
           textOptional="Valgfritt"
-          theme="radio"
-          isRequired />
-      </form>
-      <h2 id="theme" class="mt-h2">Theme - button</h2>
-      <form action="" class="mt-form form-layout">
-        <RadioGroup
-          options={buttonOptions}
-          bind:value={buttonRadioValue}
-          name={buttonRadio.name}
-          {helpText}
-          label={buttonRadio.label}
-          textOptional={buttonRadio.textOptional}
-          theme="button" />
+          isRequired={false} />
       </form>
     </div>
   {/snippet}
@@ -103,8 +91,7 @@
           {helpText}
           label={buttonRadio.label}
           error={{ key: name, message: errorMessage }}
-          textOptional={buttonRadio.textOptional}
-          theme="button" />
+          textOptional={buttonRadio.textOptional} />
       </form>
     </div>
   {/snippet}

--- a/mt-kit/core/svelte/src/stories/form/RadioButtons.stories.svelte
+++ b/mt-kit/core/svelte/src/stories/form/RadioButtons.stories.svelte
@@ -14,17 +14,6 @@
       value: 'no'
     }
   ]
-  let buttonRadioValue: string | undefined = $state('2')
-  const buttonOptions = [
-    {
-      text: 'Ja',
-      value: '1'
-    },
-    {
-      text: 'Nei',
-      value: '2'
-    }
-  ]
 
   const { Story } = defineMeta({
     title: 'Components/Form/RadioButtons',
@@ -33,13 +22,6 @@
       helpText:
         'Beskriv kort og konkret hva du har observert og hvor alvorlig hendelsen er. Vær oppmerksom på den ansvarlige ofte får se meldingen.',
       errorMessage: 'Fyll inn dette feltet.',
-      buttonRadio: {
-        label: 'Reiser du selv med dyret?',
-        helpText: 'Hjelpetekst',
-        errorMessage: 'Fyll inn dette feltet.',
-        name: 'travelWithAnimal',
-        textOptional: 'Valgfritt'
-      },
       disableCss: false
     },
     argTypes: {
@@ -52,7 +34,7 @@
 </script>
 
 <Story name="Normal">
-  {#snippet children({ label, helpText, disableCss, buttonRadio })}
+  {#snippet children({ label, helpText, disableCss })}
     <div use:wrapInShadowDom={disableCss}>
       <h1 class="mt-h1">Radioknapper</h1>
       <h2 class="mt-h2">Theme - radio</h2>
@@ -63,14 +45,14 @@
           {helpText}
           {label}
           textOptional="Valgfritt"
-          isRequired={false} />
+          isRequired />
       </form>
     </div>
   {/snippet}
 </Story>
 
 <Story name="Radio with error">
-  {#snippet children({ label, helpText, disableCss, errorMessage, buttonRadio })}
+  {#snippet children({ label, helpText, disableCss, errorMessage })}
     <div use:wrapInShadowDom={disableCss}>
       <h2 class="mt-h2">Theme - radio</h2>
       <form class="mt-form form-layout">
@@ -81,17 +63,6 @@
           {label}
           error={{ key: name, message: errorMessage }}
           textOptional="valgfritt" />
-      </form>
-      <h2 id="theme" class="mt-h2">Theme - button</h2>
-      <form class="mt-form form-layout">
-        <RadioGroup
-          options={buttonOptions}
-          bind:value={buttonRadioValue}
-          name={buttonRadio.name}
-          {helpText}
-          label={buttonRadio.label}
-          error={{ key: name, message: errorMessage }}
-          textOptional={buttonRadio.textOptional} />
       </form>
     </div>
   {/snippet}


### PR DESCRIPTION
- Removed `theme="button"` as this was not in use, and can easily be created by `Chip` from `@mattilsynet/design` if needed later on